### PR TITLE
add enums for request parameters and model properties

### DIFF
--- a/src/mustache/apiCallByPartialMap.mustache
+++ b/src/mustache/apiCallByPartialMap.mustache
@@ -11,19 +11,19 @@
    * @param reportProgress flag to report request and response progress.
    */
   public {{nickname}}ByMap(
-    map: Partial{{nickname}}ParamMap,
+    map: {{operationIdCamelCase}}.PartialParamMap,
     observe?: 'body',
     reportProgress?: boolean): Observable<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>;
   public {{nickname}}ByMap(
-    map: Partial{{nickname}}ParamMap,
+    map: {{operationIdCamelCase}}.PartialParamMap,
     observe?: 'response',
     reportProgress?: boolean): Observable<HttpResponse<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>>;
   public {{nickname}}ByMap(
-    map: Partial{{nickname}}ParamMap,
+    map: {{operationIdCamelCase}}.PartialParamMap,
     observe?: 'events',
     reportProgress?: boolean): Observable<HttpEvent<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>>;
   public {{nickname}}ByMap(
-    map: Partial{{nickname}}ParamMap,
+    map: {{operationIdCamelCase}}.PartialParamMap,
     observe: any = 'body',
     reportProgress: boolean = false): Observable<any> {
     return this.{{nickname}}({{#allParams}}

--- a/src/mustache/apiPartialMap.mustache
+++ b/src/mustache/apiPartialMap.mustache
@@ -3,12 +3,29 @@
 {{! All rights reserved. }}
 {{#operation}}
 /**
- * Parameter map for {{nickname}}.
+ * Namespace for {{nickname}}.
  */
-export interface Partial{{nickname}}ParamMap {
-{{#allParams}}
-  /** {{description}} */
-  {{paramName}}{{^required}}?{{/required}}: {{{dataType}}};
-{{/allParams}}
+export namespace {{operationIdCamelCase}} {
+    /**
+     * Parameter map for {{nickname}}.
+     */
+    export interface PartialParamMap {
+    {{#allParams}}
+      /**
+       * {{{description}}}
+       */
+      {{paramName}}{{^required}}?{{/required}}: {{{dataType}}};
+    {{/allParams}}
+    }
+
+    /**
+     * Enumeration of all parameters for {{nickname}}.
+     */
+    export enum Parameters {
+    {{#allParams}}
+        {{paramName}} = '{{paramName}}'{{^-last}},{{/-last}}
+    {{/allParams}}
+    }
 }
+
 {{/operation}}

--- a/src/mustache/modelGeneric.mustache
+++ b/src/mustache/modelGeneric.mustache
@@ -10,6 +10,7 @@ export interface {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{ {{>m
     {{/description}}
     {{#isReadOnly}}readonly {{/isReadOnly}}{{{name}}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}};
 {{/vars}}
-}{{>modelGenericEnums}}
+}
 
+{{>modelGenericEnums}}
 {{>modelGenericValidators}}

--- a/src/mustache/modelGenericEnums.mustache
+++ b/src/mustache/modelGenericEnums.mustache
@@ -1,0 +1,31 @@
+{{! Copyright(c) 1995 - 2018 T-Systems Multimedia Solutions GmbH }}
+{{! Riesaer Str. 5, 01129 Dresden }}
+{{! All rights reserved. }}
+/**
+ * Namespace for property- and property-value-enumerations of {{{classname}}}.
+ */
+export namespace {{classname}} {
+    /**
+     * All properties of {{{classname}}}.
+     */
+    export enum Properties {
+    {{#vars}}
+        {{name}} = '{{name}}'{{^-last}},{{/-last}}
+    {{/vars}}
+    }
+{{#vars}}
+    {{#isEnum}}
+
+    /**
+     * All possible values of {{{name}}}.
+     */
+    export enum {{enumName}} {
+    {{#allowableValues}}
+    {{#enumVars}}
+        {{name}} = {{{value}}}{{^-last}},{{/-last}}
+    {{/enumVars}}
+    {{/allowableValues}}
+    }
+    {{/isEnum}}
+{{/vars}}
+}


### PR DESCRIPTION
This PR will add following:
- operations now provide an enumeration of all request-parameters
- models now provide an enumeration of all properties