### PR TITLE
add validators for request parameters without own model-definition

### DIFF
--- a/src/mustache/api.service.mustache
+++ b/src/mustache/api.service.mustache
@@ -5,6 +5,7 @@
 /* tslint:disable:no-unused-variable member-ordering */
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
+{{>apiParamValidatorImports}}
 {{#useHttpClient}}
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent }                           from '@angular/common/http';

--- a/src/mustache/apiPartialMap.mustache
+++ b/src/mustache/apiPartialMap.mustache
@@ -33,6 +33,39 @@ export namespace {{operationIdCamelCase}} {
       {{paramName}} = '{{paramName}}'{{^-last}},{{/-last}}
     {{/allParams}}
     }
+
+    /**
+     * A map of tuples with error name and `ValidatorFn` for each parameter of {{nickname}}
+     * that does not have an own model.
+     */
+    export const ParamValidators: {[K in keyof {{operationIdCamelCase}}.PartialParamMap]: [string, ValidatorFn][]} = {
+    {{#allParams}}
+    {{^isModel}}
+      {{paramName}}: [
+              {{#required}}
+              ['required', Validators.required],
+              {{/required}}
+              {{#hasValidation}}
+              {{#minimum}}
+              ['min', Validators.min({{minimum}})],
+              {{/minimum}}
+              {{#maximum}}
+              ['max', Validators.max({{maximum}})],
+              {{/maximum}}
+              {{#minLength}}
+              ['minlength', Validators.minLength({{minLength}})],
+              {{/minLength}}
+              {{#maxLength}}
+              ['maxlength', Validators.maxLength({{maxLength}})],
+              {{/maxLength}}
+              {{#pattern}}
+              ['pattern', Validators.pattern({{pattern}})],
+              {{/pattern}}
+              {{/hasValidation}}
+      ],
+    {{/isModel}}
+    {{/allParams}}
+    }
 }
 
 {{/operation}}

--- a/src/mustache/modelGeneric.mustache
+++ b/src/mustache/modelGeneric.mustache
@@ -13,4 +13,3 @@ export interface {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{ {{>m
 }
 
 {{>modelGenericEnums}}
-{{>modelGenericValidators}}

--- a/src/mustache/modelGenericEnums.mustache
+++ b/src/mustache/modelGenericEnums.mustache
@@ -33,4 +33,6 @@ export namespace {{classname}} {
     }
     {{/isEnum}}
 {{/vars}}
+
+{{>modelGenericValidators}}
 }

--- a/src/mustache/modelGenericValidators.mustache
+++ b/src/mustache/modelGenericValidators.mustache
@@ -1,41 +1,41 @@
 {{! Copyright(c) 1995 - 2018 T-Systems Multimedia Solutions GmbH }}
 {{! Riesaer Str. 5, 01129 Dresden }}
 {{! All rights reserved. }}
-/**
- * A map of tubles with error name and `ValidatorFn` for each property of {{classname}}.
- */
-export const {{classname}}Validators: {[K in keyof {{classname}}]: [string, ValidatorFn][]} = {
-{{#vars}}
-    {{name}}: [
-            {{#required}}
-            ['required', Validators.required],
-            {{/required}}
-            {{#hasValidation}}
-            {{#minimum}}
-            ['min', Validators.min({{minimum}})],
-            {{/minimum}}
-            {{#maximum}}
-            ['max', Validators.max({{maximum}})],
-            {{/maximum}}
-            {{#minLength}}
-            ['minlength', Validators.minLength({{minLength}})],
-            {{/minLength}}
-            {{#maxLength}}
-            ['maxlength', Validators.maxLength({{maxLength}})],
-            {{/maxLength}}
-            {{#pattern}}
-            ['pattern', Validators.pattern({{pattern}})],
-            {{/pattern}}
-            {{/hasValidation}}
-    ],
-{{/vars}}
-};
+    /**
+    * A map of tuples with error name and `ValidatorFn` for each property of {{classname}}.
+    */
+    export const ModelValidators: {[K in keyof {{classname}}]: [string, ValidatorFn][]} = {
+    {{#vars}}
+        {{name}}: [
+                {{#required}}
+                ['required', Validators.required],
+                {{/required}}
+                {{#hasValidation}}
+                {{#minimum}}
+                ['min', Validators.min({{minimum}})],
+                {{/minimum}}
+                {{#maximum}}
+                ['max', Validators.max({{maximum}})],
+                {{/maximum}}
+                {{#minLength}}
+                ['minlength', Validators.minLength({{minLength}})],
+                {{/minLength}}
+                {{#maxLength}}
+                ['maxlength', Validators.maxLength({{maxLength}})],
+                {{/maxLength}}
+                {{#pattern}}
+                ['pattern', Validators.pattern({{pattern}})],
+                {{/pattern}}
+                {{/hasValidation}}
+        ],
+    {{/vars}}
+    };
 
-/**
- * The FormControlFactory for {{classname}}.
- */
-export class {{classname}}FormControlFactory extends BaseFormControlFactory<{{classname}}> {
-    constructor(model: {{classname}}) {
-        super(model, {{classname}}Validators);
+    /**
+    * The FormControlFactory for {{classname}}.
+    */
+    export class FormControlFactory extends BaseFormControlFactory<{{classname}}> {
+        constructor(model: {{classname}}) {
+            super(model, {{classname}}.ModelValidators);
+        }
     }
-}


### PR DESCRIPTION
This commit adds angular validators for alle request-parameters that have not an own model at the swagger-spec.

In addition, the model-validators and the formcontrol-factory are now part of the model-namespace.