### PR TITLE
Enable post processing of files

### DIFF
--- a/bin/ng-ts-codegen.js
+++ b/bin/ng-ts-codegen.js
@@ -92,9 +92,14 @@ if (!argv.o) {
 let command;
 let isDocker = false;
 if (argv.e === 'docker') {
-  const proxyArgs = getProxyArgsForDocker();
+  // transfer post processing env-variable to docker if it exists
+  let envArgs = process.env.TS_POST_PROCESS_FILE ? ` --env TS_POST_PROCESS_FILE="${process.env.TS_POST_PROCESS_FILE}"` : ''
+
+  // add proxy args
+  envArgs += getProxyArgsForDocker();
+
   const volume = argv.m || process.env.PWD;
-  command = `docker run${proxyArgs} --rm -v ${volume}:/local ${dockerImageName}`;
+  command = `docker run${envArgs} --rm -v ${volume}:/local ${dockerImageName}`;
   isDocker = true;
 } else {
   // default to java
@@ -115,6 +120,11 @@ const args = [
       : resolve(__dirname, '../src/mustache')
   }`,
 ];
+
+// enable post processing if environment variable TS_POST_PROCESS_FILE is set
+if (process.env.TS_POST_PROCESS_FILE) {
+  args.push('--enable-post-process-file',)
+}
 
 // add auth headers
 if (argv.a) {


### PR DESCRIPTION
This commit adds the post processing of files. This will be set
implicit by setting the environment variable TS_POST_PROCESS_FILE.

For the docker-way of generating the api, the environment variable must be transferred to the docker-call.

Resolves: #16