### PR TITLE
Security context and error handling

### DIFF
--- a/dist/formgroup.d.ts
+++ b/dist/formgroup.d.ts
@@ -43,12 +43,11 @@ export declare class TypedFormGroup<T> extends FormGroup {
      */
     isValidatorRegistered(name: Extract<keyof T, string>, validatorName: string): boolean;
     /**
-     * Returns an error key for the next error (<controlName>.<errorKey>).
+     * Returns an error key for the next error.
      *
      * @param name control key of the form group
-     * @param prefix to be prepend to the error key
      */
-    nextControlErrorKey(name: Extract<keyof T, string>, prefix?: string): string;
+    nextControlErrorKey(name: Extract<keyof T, string>): string;
     /**
      * Dispatches errors to this control and to child controls using given error map.
      *

--- a/dist/index.es.js
+++ b/dist/index.es.js
@@ -198,12 +198,11 @@ var TypedFormGroup = /** @class */ (function (_super) {
             this.registeredValidatorsMap[name].some(function (errorKey) { return errorKey === validatorName; }));
     };
     /**
-     * Returns an error key for the next error (<controlName>.<errorKey>).
+     * Returns an error key for the next error.
      *
      * @param name control key of the form group
-     * @param prefix to be prepend to the error key
      */
-    TypedFormGroup.prototype.nextControlErrorKey = function (name, prefix) {
+    TypedFormGroup.prototype.nextControlErrorKey = function (name) {
         var control = this.get(name);
         if (control && control.errors) {
             // try client side keys first for correct order
@@ -214,7 +213,7 @@ var TypedFormGroup = /** @class */ (function (_super) {
                 error = Object.keys(control.errors).shift();
             }
             if (error) {
-                return "" + (prefix ? prefix + "." : '') + name + "." + error;
+                return error;
             }
         }
         return '';

--- a/dist/index.js
+++ b/dist/index.js
@@ -202,12 +202,11 @@ var TypedFormGroup = /** @class */ (function (_super) {
             this.registeredValidatorsMap[name].some(function (errorKey) { return errorKey === validatorName; }));
     };
     /**
-     * Returns an error key for the next error (<controlName>.<errorKey>).
+     * Returns an error key for the next error.
      *
      * @param name control key of the form group
-     * @param prefix to be prepend to the error key
      */
-    TypedFormGroup.prototype.nextControlErrorKey = function (name, prefix) {
+    TypedFormGroup.prototype.nextControlErrorKey = function (name) {
         var control = this.get(name);
         if (control && control.errors) {
             // try client side keys first for correct order
@@ -218,7 +217,7 @@ var TypedFormGroup = /** @class */ (function (_super) {
                 error = Object.keys(control.errors).shift();
             }
             if (error) {
-                return "" + (prefix ? prefix + "." : '') + name + "." + error;
+                return error;
             }
         }
         return '';

--- a/src/formgroup.spec.ts
+++ b/src/formgroup.spec.ts
@@ -11,7 +11,7 @@ interface NestedType {
   deepValue: string;
 }
 
-test('Test FormGroupControl creation', () => {
+test('Test FormGroupControl creation #1', () => {
   const factory = new BaseFormControlFactory<TestType>(
     { value: 'testValue', nested: { deepValue: 'deepTestValue' } },
     { value: [['req', Validators.required]], nested: [] }
@@ -60,14 +60,14 @@ test('Test FormGroupControl creation', () => {
   expect(nestedGroup.hasControlErrors('deepValue')).toBe(true);
   expect(group.isValidatorRegistered('value', 'required')).toBe(false);
   expect(nestedGroup.isValidatorRegistered('deepValue', 'required')).toBe(false);
-  expect(group.nextControlErrorKey('value')).toBe('value.req');
-  expect(nestedGroup.nextControlErrorKey('deepValue')).toBe('deepValue.req');
+  expect(group.nextControlErrorKey('value')).toBe('req');
+  expect(nestedGroup.nextControlErrorKey('deepValue')).toBe('req');
 
   valueControl.setErrors({ other: 'Other Error!' });
-  expect(group.nextControlErrorKey('value')).toBe('value.other');
+  expect(group.nextControlErrorKey('value')).toBe('other');
 });
 
-test('Test FormGroupControl creation', () => {
+test('Test FormGroupControl creation #2', () => {
   const nestedFactory = new BaseFormControlFactory<NestedType>(
     { deepValue: 'deepTestValue' },
     { deepValue: [['req', Validators.required]] }

--- a/src/formgroup.ts
+++ b/src/formgroup.ts
@@ -88,12 +88,11 @@ export class TypedFormGroup<T> extends FormGroup {
   }
 
   /**
-   * Returns an error key for the next error (<controlName>.<errorKey>).
+   * Returns an error key for the next error.
    *
    * @param name control key of the form group
-   * @param prefix to be prepend to the error key
    */
-  nextControlErrorKey(name: Extract<keyof T, string>, prefix?: string): string {
+  nextControlErrorKey(name: Extract<keyof T, string>): string {
     const control = this.get(name);
     if (control && control.errors) {
       // try client side keys first for correct order
@@ -105,7 +104,7 @@ export class TypedFormGroup<T> extends FormGroup {
         error = Object.keys(control.errors).shift();
       }
       if (error) {
-        return `${prefix ? `${prefix}.` : ''}${name}.${error}`;
+        return error;
       }
     }
     return '';

--- a/src/mustache/api.module.mustache
+++ b/src/mustache/api.module.mustache
@@ -1,0 +1,41 @@
+{{! Copyright(c) 1995 - 2018 T-Systems Multimedia Solutions GmbH }}
+{{! Riesaer Str. 5, 01129 Dresden }}
+{{! All rights reserved. }}
+import { NgModule, ModuleWithProviders, SkipSelf, Optional } from '@angular/core';
+import { Configuration } from './configuration';
+{{#useHttpClient}}import { HttpClient } from '@angular/common/http';{{/useHttpClient}}
+{{^useHttpClient}}import { Http } from '@angular/http';{{/useHttpClient}}
+
+{{#apiInfo}}
+{{#apis}}
+import { {{classname}} } from './{{importPath}}';
+{{/apis}}
+{{/apiInfo}}
+
+@NgModule({
+  imports:      [],
+  declarations: [],
+  exports:      [],
+  providers: [
+    {{#apiInfo}}{{#apis}}{{classname}}{{#hasMore}},
+    {{/hasMore}}{{/apis}}{{/apiInfo}} ]
+})
+export class ApiModule {
+    public static forRoot(configurationFactory: (...args: any[]) => Configuration, deps?: any[]): ModuleWithProviders {
+        return {
+            ngModule: ApiModule,
+            providers: [ { provide: Configuration, useFactory: configurationFactory, deps } ]
+        };
+    }
+
+    constructor( @Optional() @SkipSelf() parentModule: ApiModule,
+                 @Optional() http: {{#useHttpClient}}HttpClient{{/useHttpClient}}{{^useHttpClient}}Http{{/useHttpClient}}) {
+        if (parentModule) {
+            throw new Error('ApiModule is already loaded. Import in your base AppModule only.');
+        }
+        if (!http) {
+            throw new Error('You need to import the {{#useHttpClient}}HttpClientModule{{/useHttpClient}}{{^useHttpClient}}HttpModule{{/useHttpClient}} in your AppModule! \n' +
+            'See also https://github.com/angular/angular/issues/20575');
+        }
+    }
+}

--- a/src/mustache/api.service.mustache
+++ b/src/mustache/api.service.mustache
@@ -23,6 +23,7 @@ import { Observable }                                        from 'rxjs/Observab
 {{/useRxJS6}}
 {{#useRxJS6}}
 import { Observable }                                        from 'rxjs';
+import { catchError }                                        from 'rxjs/operators';
 {{/useRxJS6}}
 {{^useHttpClient}}
 import '../rxjs-operators';
@@ -311,7 +312,7 @@ export class {{classname}} {
 
 {{/hasFormParams}}
 {{#useHttpClient}}
-        return this.httpClient.{{httpMethod}}{{^isResponseFile}}<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>{{/isResponseFile}}(`${this.configuration.basePath}{{{path}}}`,{{#isBodyAllowed}}
+        const handle = this.httpClient.{{httpMethod}}{{^isResponseFile}}<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>{{/isResponseFile}}(`${this.configuration.basePath}{{{path}}}`,{{#isBodyAllowed}}
             {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}{{#hasFormParams}}convertFormParamsToString ? formParams.toString() : formParams{{/hasFormParams}}{{^hasFormParams}}null{{/hasFormParams}}{{/bodyParam}},{{/isBodyAllowed}}
             {
 {{#hasQueryParams}}
@@ -326,6 +327,10 @@ export class {{classname}} {
                 reportProgress: reportProgress
             }
         );
+        if(typeof this.configuration.errorHandler === 'function') {
+          return handle.pipe(catchError(err => this.configuration.errorHandler(err)));
+        }
+        return handle;
 {{/useHttpClient}}
 {{^useHttpClient}}
         let requestOptions: RequestOptionsArgs = new RequestOptions({
@@ -350,7 +355,11 @@ export class {{classname}} {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
-        return this.http.request(`${this.configuration.basePath}{{{path}}}`, requestOptions);
+        const handle = this.http.request(`${this.configuration.basePath}{{{path}}}`, requestOptions);
+        if(typeof this.configuration.errorHandler === 'function') {
+          return handle.catch(err => this.configuration.errorHandler(err));
+        }
+        return handle;
 {{/useHttpClient}}
     }
 

--- a/src/mustache/api.service.mustache
+++ b/src/mustache/api.service.mustache
@@ -328,7 +328,7 @@ export class {{classname}} {
             }
         );
         if(typeof this.configuration.errorHandler === 'function') {
-          return handle.pipe(catchError(err => this.configuration.errorHandler(err)));
+          return handle.pipe(catchError(err => this.configuration.errorHandler(err, '{{operationIdOriginal}}')));
         }
         return handle;
 {{/useHttpClient}}
@@ -357,7 +357,7 @@ export class {{classname}} {
 
         const handle = this.http.request(`${this.configuration.basePath}{{{path}}}`, requestOptions);
         if(typeof this.configuration.errorHandler === 'function') {
-          return handle.catch(err => this.configuration.errorHandler(err));
+          return handle.catch(err => this.configuration.errorHandler(err, '{{operationIdOriginal}}'));
         }
         return handle;
 {{/useHttpClient}}

--- a/src/mustache/configuration.mustache
+++ b/src/mustache/configuration.mustache
@@ -1,0 +1,90 @@
+{{! Copyright(c) 1995 - 2018 T-Systems Multimedia Solutions GmbH }}
+{{! Riesaer Str. 5, 01129 Dresden }}
+{{! All rights reserved. }}
+{{^useRxJS6}}
+import { Observable }                                        from 'rxjs/Observable';
+{{/useRxJS6}}
+{{#useRxJS6}}
+import { Observable }                                        from 'rxjs';
+{{/useRxJS6}}
+
+export interface ConfigurationParameters {
+    apiKeys?: {[ key: string ]: string};
+    username?: string;
+    password?: string;
+    accessToken?: string | (() => string);
+    errorHandler?: (err: any) => Observable<never>;
+    basePath?: string;
+    withCredentials?: boolean;
+}
+
+export class Configuration {
+    apiKeys?: {[ key: string ]: string};
+    username?: string;
+    password?: string;
+    accessToken?: string | (() => string);
+    basePath?: string;
+    withCredentials?: boolean;
+
+    constructor(configurationParameters: ConfigurationParameters = {}) {
+        this.apiKeys = configurationParameters.apiKeys;
+        this.username = configurationParameters.username;
+        this.password = configurationParameters.password;
+        this.accessToken = configurationParameters.accessToken;
+        this.basePath = configurationParameters.basePath;
+        this.withCredentials = configurationParameters.withCredentials;
+    }
+
+    /**
+     * Select the correct content-type to use for a request.
+     * Uses {@link Configuration#isJsonMime} to determine the correct content-type.
+     * If no content type is found return the first found type if the contentTypes is not empty
+     * @param contentTypes - the array of content types that are available for selection
+     * @returns the selected content-type or <code>undefined</code> if no selection could be made.
+     */
+    public selectHeaderContentType (contentTypes: string[]): string | undefined {
+        if (contentTypes.length === 0) {
+            return undefined;
+        }
+
+        let type = contentTypes.find(x => this.isJsonMime(x));
+        if (type === undefined) {
+            return contentTypes[0];
+        }
+        return type;
+    }
+
+    /**
+     * Select the correct accept content-type to use for a request.
+     * Uses {@link Configuration#isJsonMime} to determine the correct accept content-type.
+     * If no content type is found return the first found type if the contentTypes is not empty
+     * @param accepts - the array of content types that are available for selection.
+     * @returns the selected content-type or <code>undefined</code> if no selection could be made.
+     */
+    public selectHeaderAccept(accepts: string[]): string | undefined {
+        if (accepts.length === 0) {
+            return undefined;
+        }
+
+        let type = accepts.find(x => this.isJsonMime(x));
+        if (type === undefined) {
+            return accepts[0];
+        }
+        return type;
+    }
+
+    /**
+     * Check if the given MIME is a JSON MIME.
+     * JSON MIME examples:
+     *   application/json
+     *   application/json; charset=UTF8
+     *   APPLICATION/JSON
+     *   application/vnd.company+json
+     * @param mime - MIME (Multipurpose Internet Mail Extensions)
+     * @return True if the given MIME is JSON, false otherwise.
+     */
+    public isJsonMime(mime: string): boolean {
+        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
+        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+    }
+}

--- a/src/mustache/configuration.mustache
+++ b/src/mustache/configuration.mustache
@@ -2,10 +2,10 @@
 {{! Riesaer Str. 5, 01129 Dresden }}
 {{! All rights reserved. }}
 {{^useRxJS6}}
-import { Observable }                                        from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 {{/useRxJS6}}
 {{#useRxJS6}}
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 {{/useRxJS6}}
 
 export interface ConfigurationParameters {
@@ -13,7 +13,7 @@ export interface ConfigurationParameters {
     username?: string;
     password?: string;
     accessToken?: string | (() => string);
-    errorHandler?: (err: any) => Observable<never>;
+    errorHandler?: (err: any, operationName: string) => Observable<never>;
     basePath?: string;
     withCredentials?: boolean;
 }
@@ -23,7 +23,7 @@ export class Configuration {
     username?: string;
     password?: string;
     accessToken?: string | (() => string);
-    errorHandler?: (err: any) => Observable<never>;
+    errorHandler?: (err: any, operationName: string) => Observable<never>;
     basePath?: string;
     withCredentials?: boolean;
 

--- a/src/mustache/configuration.mustache
+++ b/src/mustache/configuration.mustache
@@ -23,6 +23,7 @@ export class Configuration {
     username?: string;
     password?: string;
     accessToken?: string | (() => string);
+    errorHandler?: (err: any) => Observable<never>;
     basePath?: string;
     withCredentials?: boolean;
 
@@ -31,6 +32,7 @@ export class Configuration {
         this.username = configurationParameters.username;
         this.password = configurationParameters.password;
         this.accessToken = configurationParameters.accessToken;
+        this.errorHandler = configurationParameters.errorHandler;
         this.basePath = configurationParameters.basePath;
         this.withCredentials = configurationParameters.withCredentials;
     }


### PR DESCRIPTION
* adds the possibility to provide dependecies to the configuration factory by passing an array with classes as second argument to forRoot
* adds the possibility to add an error handler for requests
  * should return an observable and gets the error object and the operationId
* accessToken handler can now use dependecies of the configuration factory method
* nextControlErrorKey now only returns only the error key, no concatenation ist returned