### PR TITLE
Fix compile error in TypedFormControl when using Angular 15

### DIFF
--- a/dist/formcontrol.d.ts
+++ b/dist/formcontrol.d.ts
@@ -1,4 +1,4 @@
-import { FormControl, ValidatorFn, AsyncValidatorFn } from '@angular/forms';
+import { FormControl, ValidatorFn, AsyncValidatorFn, FormControlStatus } from '@angular/forms';
 import { Observable } from 'rxjs';
 /**
  * Validator options to have mapping key -> validator function.
@@ -23,7 +23,7 @@ export declare class TypedFormControl<T> extends FormControl {
     /** @inheritdoc */
     readonly valueChanges: Observable<T>;
     /** @inheritdoc */
-    readonly statusChanges: Observable<T>;
+    readonly statusChanges: Observable<FormControlStatus>;
     /** holds all possible validator names extracted by the given validators */
     readonly registeredValidators: string[];
     /** @inheritdoc */


### PR DESCRIPTION
I know this change isn't necessary (yet) since this project is still on Angular 10, but in Angular version 15 `statusChanges` uses the `FormControlStatus`.